### PR TITLE
Bring back the swirlies and mikazuki villa

### DIFF
--- a/api/gacha.py
+++ b/api/gacha.py
@@ -393,8 +393,6 @@ def draw():
             # 3 = no swirlies
             # 4 = swirlies
             directionType = 3
-            #with open("/tmp/rarity.txt", "wt") as f:
-            #    f.write("%d" % result['cardList'][0]['card']['rank'])
             if result['cardList'][0]['card']['rank'] == "RANK_4":
                 directionType = 4
             responseList.append({
@@ -439,8 +437,8 @@ def draw():
             "live2dDetail": gachaKind['live2dDetail'],
             "messageId": gachaKind['messageId'],
             "message": gachaKind['message'],
-            # TODO: i'm guessing each 'direction' determines which picture
-            # to show
+            # 'directionX' controls what is shown as each of the 3 pictures
+            # in the opening animation
             "direction1": 1,
             "direction2": 1,
             "direction3": 1,
@@ -462,8 +460,6 @@ def draw():
         # (other 2 pics are always flower-thingy and mokyuu)
         gachaAnimation["direction2AttributeId"] = das_attribute
 
-    with open("/tmp/gacha.txt", "wt") as f:
-        f.write(json.dumps(gachaAnimation))
     if pityGroup is not None:
         gachaAnimation["userGachaGroup"] = pityGroup
     response = {

--- a/api/gacha.py
+++ b/api/gacha.py
@@ -439,7 +439,7 @@ def draw():
             #
             # first picture
             # 1 = flower thingy
-            # 2 = inverted flower thingy?
+            # 2 = inverted flower thingy
             "direction1": 1,
             #
             # second picture

--- a/api/gacha.py
+++ b/api/gacha.py
@@ -390,10 +390,11 @@ def draw():
                 userCardList.append(card)
                 userLive2dList.append(live2d)
             userCharaList.append(chara)
-            # 3 = no swirlies
-            # 4 = swirlies
-            directionType = 3
-            if result['cardList'][0]['card']['rank'] == "RANK_4":
+            # set swirly animation based on rarity (4 == rainbow)
+            directionType = 2
+            if result['cardList'][0]['card']['rank'][-1] == "3":
+                directionType = 3
+            elif result['cardList'][0]['card']['rank'][-1] == "4":
                 directionType = 4
             responseList.append({
                 "type": "CARD",
@@ -402,9 +403,6 @@ def draw():
                 "cardId": result['cardList'][0]['cardId'],
                 "attributeId": result['chara']['attributeId'],
                 "charaId": result['charaId'],
-                # NOTE: controls swirlies
-                # 3 = no swirlies
-                # 4 = swirlies
                 "direction": directionType,
                 "displayName": result['chara']['name'],
                 "isNew": not foundExisting

--- a/api/gacha.py
+++ b/api/gacha.py
@@ -455,9 +455,7 @@ def draw():
 
     if got_a_4_star:
         gachaAnimation["direction3"] = 3
-        # TODO: direction3 works (shows mikazuki villa) but
-        # for some reason direction2AttributeId has no effect
-        # (other 2 pics are always flower-thingy and mokyuu)
+        # to show attribute as 2nd picture, direction2 must == 2
         gachaAnimation["direction2AttributeId"] = das_attribute
 
     if pityGroup is not None:

--- a/api/gacha.py
+++ b/api/gacha.py
@@ -390,6 +390,13 @@ def draw():
                 userCardList.append(card)
                 userLive2dList.append(live2d)
             userCharaList.append(chara)
+            # 3 = no swirlies
+            # 4 = swirlies
+            directionType = 3
+            #with open("/tmp/rarity.txt", "wt") as f:
+            #    f.write("%d" % result['cardList'][0]['card']['rank'])
+            if result['cardList'][0]['card']['rank'] == "RANK_4":
+                directionType = 4
             responseList.append({
                 "type": "CARD",
                 "rarity": result['cardList'][0]['card']['rank'],
@@ -397,7 +404,10 @@ def draw():
                 "cardId": result['cardList'][0]['cardId'],
                 "attributeId": result['chara']['attributeId'],
                 "charaId": result['charaId'],
-                "direction": 3,
+                # NOTE: controls swirlies
+                # 3 = no swirlies
+                # 4 = swirlies
+                "direction": directionType,
                 "displayName": result['chara']['name'],
                 "isNew": not foundExisting
             })
@@ -424,17 +434,36 @@ def draw():
     userItemList += \
         spend(gachaKind['needPointKind'], gachaKind['needQuantity'], gachaKind['substituteItemId'] if 'substituteItemId' in gachaKind else None)
 
-
     # create response
     gachaAnimation = {
             "live2dDetail": gachaKind['live2dDetail'],
             "messageId": gachaKind['messageId'],
             "message": gachaKind['message'],
+            # TODO: i'm guessing each 'direction' determines which picture
+            # to show
             "direction1": 1,
             "direction2": 1,
             "direction3": 1,
             "gachaResultList": responseList
         }
+
+    got_a_4_star = False
+    das_attribute = None
+    for card in responseList:
+        if card["rarity"] == "RANK_4":
+            got_a_4_star = True
+            das_attribute = card["attributeId"]
+            break
+
+    if got_a_4_star:
+        gachaAnimation["direction3"] = 3
+        # TODO: direction3 works (shows mikazuki villa) but
+        # for some reason direction2AttributeId has no effect
+        # (other 2 pics are always flower-thingy and mokyuu)
+        gachaAnimation["direction2AttributeId"] = das_attribute
+
+    with open("/tmp/gacha.txt", "wt") as f:
+        f.write(json.dumps(gachaAnimation))
     if pityGroup is not None:
         gachaAnimation["userGachaGroup"] = pityGroup
     response = {

--- a/api/gacha.py
+++ b/api/gacha.py
@@ -2,6 +2,7 @@ import flask
 import json
 import os
 import numpy as np
+import random
 from datetime import datetime
 from uuid import uuid1
 
@@ -466,6 +467,13 @@ def draw():
         gachaAnimation["direction3"] = 3
         # to show attribute as 2nd picture, direction2 must == 2
         gachaAnimation["direction2AttributeId"] = das_attribute
+    else:
+        # randomly show attribute if didn't pull a 4 star
+        if random.randint(1, 2) == 2:
+             # pick a card, any card
+             random_card = random.choice([a for a in responseList if a["type"] == "CARD"])
+             gachaAnimation["direction2"] = 2
+             gachaAnimation["direction2AttributeId"] = random_card["attributeId"]
 
     if pityGroup is not None:
         gachaAnimation["userGachaGroup"] = pityGroup

--- a/api/gacha.py
+++ b/api/gacha.py
@@ -437,11 +437,22 @@ def draw():
             "live2dDetail": gachaKind['live2dDetail'],
             "messageId": gachaKind['messageId'],
             "message": gachaKind['message'],
-            # 'directionX' controls what is shown as each of the 3 pictures
-            # in the opening animation
+            # Determines which picture to show in the intro animation
+            #
+            # first picture
+            # 1 = flower thingy
+            # 2 = inverted flower thingy?
             "direction1": 1,
+            #
+            # second picture
+            # 1 = mokyuu
+            # 2 = attribute (specified with "direction2AttributeId")
             "direction2": 1,
-            "direction3": 1,
+            #
+            # third picture
+            # 1 = spear thingy
+            # 2 = iroha
+            # 3 = mikazuki villa
             "gachaResultList": responseList
         }
 

--- a/api/gacha.py
+++ b/api/gacha.py
@@ -457,7 +457,7 @@ def draw():
     got_a_4_star = False
     das_attribute = None
     for card in responseList:
-        if card["rarity"] == "RANK_4":
+        if card["type"] == "CARD" and card["rarity"] == "RANK_4":
             got_a_4_star = True
             das_attribute = card["attributeId"]
             break


### PR DESCRIPTION
Quick patch to bring back the rainbow swirlies and mikazuki villa when pulling a 4* in gacha.
For some reason I can't get the card attribute to show tho :(
