### PR TITLE
Improvments to startup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ folder from the old one to the new one.
 
 The first time before you run the server on Windows, you need to do some setup:
 1. Run setupServer.bat.
-2. Three cmd windows should pop up. Wait until they close by themselves.
+2. A cmd window should pop up. Wait until it closes by itself.
 3. There should now be a new file named "ca.crt" in the server directory. Install this certificate on your phone -- on Android
 you can just move it on there and install it through settings/security, but on iOS you have to email it to yourself or download
 it through Safari, then make sure you trust it through Certificate Trust Settings after it's installed.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,15 @@ folder from the old one to the new one.
 
 The first time before you run the server on Windows, you need to do some setup:
 1. Run setupServer.bat.
-2. Three cmd windows should pop up. One of them may immediately say "ERROR: The process "nginx.exe" not found."; you can close
-this safely. Wait until the others close by themselves.
+2. Three cmd windows should pop up. Wait until they close by themselves.
 3. There should now be a new file named "ca.crt" in the server directory. Install this certificate on your phone -- on Android
 you can just move it on there and install it through settings/security, but on iOS you have to email it to yourself or download
 it through Safari, then make sure you trust it through Certificate Trust Settings after it's installed.
 
-You only need to do this once.
+You only need to do this once. You'll have to repeat step 3 after running setupServer.bat again. 
 
-Then, to actually run the server, run startServer.bat. Two cmd windows should pop up without immediately closing; don't 
-close either of them until you want to stop the server. That's all.
+Then, to actually run the server, run startServer.bat. A cmd windows should pop up without immediately closing; don't 
+close it until you want to stop the server. That's all.
 
 #### If you’re not on Windows
 

--- a/dnserver.py
+++ b/dnserver.py
@@ -63,4 +63,5 @@ def startDNS():
     reactor.listenUDP(53, protocol)
     reactor.listenTCP(53, factory)
 
+    print("DNS server started")
     reactor.run()

--- a/gevent_server.py
+++ b/gevent_server.py
@@ -9,4 +9,5 @@ if __name__ == '__main__':
     dnsprocess = Process(target=startDNS)
     dnsprocess.start()
     http_server = WSGIServer(('127.0.0.1', 5000), app)
+    print("App server started")
     http_server.serve_forever()

--- a/setupServer.bat
+++ b/setupServer.bat
@@ -1,4 +1,5 @@
+@echo off
 rem nginx needs to be restarted before it'll accept the new cert generated
-START windows\nginx_windows\stop-nginx.bat > NUL 2>&1
-START /WAIT windows\generate_cert.exe
+CALL windows\nginx_windows\stop-nginx.bat > NUL 2>&1
+windows\generate_cert.exe
 copy /y windows\nginx_windows\nginx\conf\cert\ca.crt ca.crt

--- a/setupServer.bat
+++ b/setupServer.bat
@@ -1,4 +1,4 @@
 rem nginx needs to be restarted before it'll accept the new cert generated
-START windows\nginx_windows\stop-nginx.bat
+START windows\nginx_windows\stop-nginx.bat > NUL 2>&1
 START /WAIT windows\generate_cert.exe
 copy /y windows\nginx_windows\nginx\conf\cert\ca.crt ca.crt

--- a/startServer.bat
+++ b/startServer.bat
@@ -1,2 +1,4 @@
-START windows\gevent_server\gevent_server.exe
-START windows\nginx_windows\start-nginx.bat
+@echo off
+CALL windows\nginx_windows\stop-nginx.bat > NUL 2>&1
+START /B windows\nginx_windows\start-nginx.bat
+windows\gevent_server\gevent_server.exe


### PR DESCRIPTION
- Run nginx and server in single cmd
- Add log when starting app and dns servers
- Stop nginx before starting the server, just in case, I've seen it stay open even after closing cmd window
- Hide scary logs when stopping nginx
- Setup now just uses single window which closes itself properly