### PR TITLE
An alternate means of installing and running ZipZap, works on all OS's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ transferUserData
 data/extra_ignore
 extra_scripts
 dist
+.vagrant
+ssl

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ An alternate method is available, that will run ZipZap in its own self-contained
 
 You will need to download and install [VirtualBox](https://www.virtualbox.org/) (**be sure and also download and install
 the VirtualBox Guest Additions**) as well as [Vagrant](https://www.vagrantup.com/). Both of these apps are completely
-free for personal/non-commercial use. Once these are installed, simply type `vagrant up`. This will automatically
-configure ZipZap and run it.
+free for personal/non-commercial use. Once these are installed, simply open a terminal in the server window and type 
+`vagrant up`. This will automatically configure ZipZap and run it.
 
 In some rare cases, Vagrant will ask you for which network interface you would like to use as the bridge interface.
 Usually the topmost choice is the right one, but in some rare instances you will have to choose one of the other

--- a/README.md
+++ b/README.md
@@ -24,16 +24,25 @@ You only need to do this once.
 Then, to actually run the server, run startServer.bat. Two cmd windows should pop up without immediately closing; don't 
 close either of them until you want to stop the server. That's all.
 
-#### If you’re not on Windows
+#### Alternate installation method
 
-Currently, there isn't support for other systems out of the box. You'll have to get nginx for your system, copy over the
-conf in windows/nginx, and run `makecert.sh` in the directory where certs are stored for nginx. Then, if you have Python 3,
-you can run `pip install -r requirements.txt`. Finally, to start the server, in two separate terminals, you'll need to run 
-nginx, and `python gevent_server.py`.
+An alternate method is available, that will run ZipZap in its own self-contained Linux virtual machine. This method can be used on both Windows, Mac and Linux.
 
-The server runs on a flask backend and nginx frontend, and uses a custom DNS server to redirect all requests to
-android.magica-us.com and ios.magica-us.com to the computer running it. Currently there's no way to config the ports that
-the server uses, but it needs 53 for DNS, 5000 for flask, and 443 for nginx.
+You will need to download and install [VirtualBox](https://www.virtualbox.org/) (**be sure and also download and install
+the VirtualBox Guest Additions**) as well as [Vagrant](https://www.vagrantup.com/). Once these are installed, simply type
+`vagrant up`. This will automatically configure ZipZap and run it.
+
+In some rare cases, Vagrant will ask you for which network interface you would like to use as the bridge interface.
+Usually the topmost choice is the right one, but in some rare instances you will have to choose one of the other
+options. If the option you choose didn't work, run `vagrant destroy` followed by `vagrant up` and try a different
+choice.
+
+Once the configuration process is complete, the script will display the VM's IP address. On your device or emulator,
+set the DNS server to that IP address, then open a web browser and go to `https://magica.us`. You should see a page
+asking you to install the custom SSL certificate. Follow the instructions to do this. Now you should be able to run
+Magia Record and connect to your private server!
+
+To start up the private server VM, run `vagrant up`; and to shut it down run `vagrant halt`.
 
 ### On your phone/tablet/emulator: connecting to the private server
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ close either of them until you want to stop the server. That's all.
 An alternate method is available, that will run ZipZap in its own self-contained Linux virtual machine. This method can be used on both Windows, Mac and Linux.
 
 You will need to download and install [VirtualBox](https://www.virtualbox.org/) (**be sure and also download and install
-the VirtualBox Guest Additions**) as well as [Vagrant](https://www.vagrantup.com/). Once these are installed, simply type
-`vagrant up`. This will automatically configure ZipZap and run it.
+the VirtualBox Guest Additions**) as well as [Vagrant](https://www.vagrantup.com/). Both of these apps are completely
+free for personal/non-commercial use. Once these are installed, simply type `vagrant up`. This will automatically
+configure ZipZap and run it.
 
 In some rare cases, Vagrant will ask you for which network interface you would like to use as the bridge interface.
 Usually the topmost choice is the right one, but in some rare instances you will have to choose one of the other

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 # Grab the name of the default interface
 # If your host machine is running Windows, this command will most likely fail
-$default_network_interface = `ip route | awk '/^default/ {printf "%s", $5; exit 0}'`
+#$default_network_interface = `ip route | awk '/^default/ {printf "%s", $5; exit 0}'`
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
@@ -42,7 +42,8 @@ Vagrant.configure("2") do |config|
   # Bridged networks make the machine appear as another physical device on
   # your network.
   #config.vm.network "public_network"
-  config.vm.network "public_network", bridge: "#$default_network_interface"
+  config.vm.network "public_network"
+  #config.vm.network "public_network", bridge: "#$default_network_interface"
 
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,6 +69,6 @@ Vagrant.configure("2") do |config|
   # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
-    /ZipZap/vagrant/setup.sh
+    /ZipZap/setupServer.sh
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Grab the name of the default interface
+# If your host machine is running Windows, this command will most likely fail
+$default_network_interface = `ip route | awk '/^default/ {printf "%s", $5; exit 0}'`
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/focal64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  #config.vm.network "public_network"
+  config.vm.network "public_network", bridge: "#$default_network_interface"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/ZipZap"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    /ZipZap/vagrant/setup.sh
+  SHELL
+end

--- a/getipaddress.sh
+++ b/getipaddress.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+i=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | tail -1)
+echo $i

--- a/restart_server.sh
+++ b/restart_server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+PID=$(ps ax | grep gevent_server | grep -v grep | awk '{ print $1 }')
+echo $PID
+kill $PID

--- a/setupServer.sh
+++ b/setupServer.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# get path to where this script (and the other ZipZap files) are located
+SRC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# must be run as root
+if [ "$EUID" -ne 0 ]; then
+  echo "This script must be run as root."
+  exit 1
+fi
+
+# install dependencies
+echo "*** BEGINNING ZIPZAP VM SETUP ***"
+echo ""
+echo "# Installing packages..."
+apt update -y -qq
+apt install -y build-essential net-tools nginx python3 python3-dev python3-pip unbound -qq
+
+# disable resolved
+echo ""
+echo "# Disabling Ubuntu DNS manager..."
+systemctl disable systemd-resolved.service
+systemctl stop systemd-resolved
+rm -f /etc/resolv.conf
+cat << _RESOLV_ > /etc/resolv.conf
+nameserver 8.8.8.8
+_RESOLV_
+
+# set up nginx
+echo ""
+echo "# Setting up nginx web server in proxy mode..."
+systemctl stop nginx.service
+mv /etc/nginx /etc/nginx.bak
+cp -r $SRC/windows/nginx_windows/nginx/conf /etc/nginx
+cp -r $SRC/windows/nginx_windows/nginx/html /etc/nginx/html
+cat << _EOF_HTML_ > /etc/nginx/html/index.html
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to MadokaPriv!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to MadokaPriv!</h1>
+<p>To use MadokaPriv to play with your Magia Record EN private server, you need to install the CA certificate and trust it</p>
+
+<p><a href="ca.crt">Download CA Cert</a>.<br/></p>
+<h2>Guides to enabling a CA Root Certificate</h2>
+<p><a href="https://support.apple.com/en-us/HT204477">iOS/iPadOS</a></p>
+<p><a href="https://www.lastbreach.com/blog/importing-private-ca-certificates-in-android">Android</a></p>
+</body>
+</html>
+_EOF_HTML_
+sed -e 's/^.*root.*html/root \/etc\/nginx\/html/' -i.bak /etc/nginx/nginx.conf
+sed -e 's/^error_log.*$/error_log \/var\/log\/nginx\/error.log;/' -i.bak /etc/nginx/nginx.conf
+sed -e 's/^.*access_log.*$/access_log \/var\/log\/nginx\/access.log combined;/' -i.bak /etc/nginx/nginx.conf
+sed -e 's/^daemon/#daemon/' -i.bak /etc/nginx/nginx.conf
+mkdir -p /var/log/nginx
+
+# set up certificate
+echo ""
+echo "# Generating SSL certificate..."
+cd $SRC && mkdir ssl
+cd ssl
+openssl genrsa -out ca.key 4096
+openssl req -new -x509 -nodes -days 3650 -key ca.key -sha256 -extensions v3_ca -subj "/C=US/ST=NA/L=NA/O=NA/CN=*.magica-us.com" -out ca.crt
+openssl req -config $SRC/site.conf -new -newkey rsa:4096 -nodes -keyout site.key -days 730 -subj "/C=US/ST=NA/L=NA/O=NA/CN=*.magica-us.com" -out site.req
+openssl x509 -sha256 -req -in site.req -CA ca.crt -CAkey ca.key -CAcreateserial -out site.crt -days 730 -extensions req_extensions -extensions cert_extensions -extfile $SRC/site.conf
+
+# install cert
+echo ""
+echo "# Installikng SSL certificate and starting up nginx..."
+mkdir -p /etc/nginx/cert /etc/nginx/html
+cp ca.crt /etc/nginx/html
+for FILE in site.crt site.key; do
+  cp "$FILE" /etc/nginx/cert/
+done
+# start nginx
+systemctl start nginx.service
+
+# install dependencies etc
+echo ""
+echo "# Installikng ZipZap python dependencies..."
+cd $SRC && pip3 install -r requirements.txt
+
+# enable rc.local
+echo ""
+echo "# Enabling ZipZap autostart at boot..."
+cat << _RCLOCAL_ > /etc/systemd/system/rc-local.service
+[Unit]
+Description=/etc/rc.local Compatibility
+ConditionPathExists=/etc/rc.local
+
+[Service]
+Type=forking
+ExecStart=/etc/rc.local start
+TimeoutSec=0
+StandardOutput=tty
+RemainAfterExit=yes
+SysVStartPriority=99
+
+[Install]
+WantedBy=multi-user.target
+_RCLOCAL_
+cat << _RCLOCAL2_ > /etc/rc.local
+#!/bin/bash
+cd $SRC && ./startServer.sh &
+exit 0
+_RCLOCAL2_
+chmod +x /etc/rc.local
+systemctl enable rc-local
+
+# start it up
+echo ""
+echo "# Starting ZipZap..."
+cd $SRC && ./startServer.sh &
+
+echo ""
+echo "*** ALL DONE! ***"
+echo ""
+sh /etc/rc.local > /tmp/local 2>&1
+i=`$SRC/getipaddress.sh`
+echo "This VM's public IP is: $i"
+echo "Set your device/emulator's DNS to that address."

--- a/site.conf
+++ b/site.conf
@@ -1,0 +1,63 @@
+[ req ]
+default_bits        = 2048
+default_keyfile     = site.pem
+distinguished_name  = subject
+req_extensions      = req_extensions
+x509_extensions     = cert_extensions
+string_mask         = utf8only
+
+[ subject ]
+countryName         = Country Name (2 letter code)
+countryName_default     = US
+
+stateOrProvinceName     = State or Province Name (full name)
+stateOrProvinceName_default = NA
+
+localityName            = Locality Name (eg, city)
+localityName_default        = NA
+
+organizationName         = Organization Name (eg, company)
+organizationName_default    = NA
+
+# Use a friendly name here. Its presented to the user.
+#   The server's DNS name show up in Subject Alternate Names. Plus, 
+#   DNS names here is deprecated by both IETF and CA/Browser Forums.
+commonName          = Common Name (e.g. server FQDN or YOUR name)
+commonName_default      = *.magica-us.com
+
+emailAddress            = Email Address
+emailAddress_default        = 
+
+[ cert_extensions ]
+
+subjectKeyIdentifier        = hash
+authorityKeyIdentifier  = keyid,issuer
+
+basicConstraints        = CA:FALSE
+keyUsage            = digitalSignature, keyEncipherment
+extendedKeyUsage  = serverAuth, clientAuth
+subjectAltName          = @alternate_names
+nsComment           = "OpenSSL Generated Certificate"
+
+[ req_extensions ]
+
+subjectKeyIdentifier        = hash
+
+basicConstraints        = CA:FALSE
+keyUsage            = digitalSignature, keyEncipherment
+extendedKeyUsage  = serverAuth, clientAuth
+subjectAltName          = @alternate_names
+nsComment           = "OpenSSL Generated Certificate"
+
+[ alternate_names ]
+
+DNS.1       = *.magica-us.com
+DNS.2       = magica-us.com
+DNS.3       = *.xn--80axfjoj.xn--p1ai
+DNS.4       = xn--80axfjoj.xn--p1ai
+
+# Add these if you need them. But usually you don't want them or
+#   need them in production. You may need them for development.
+# DNS.5       = localhost
+# DNS.6       = localhost.localdomain
+# DNS.7       = 127.0.0.1

--- a/startServer.sh
+++ b/startServer.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+cd /ZipZap
+i=`./getipaddress.sh`
+echo "IP address is $i"
+echo "Updating DNS"
+cat << _EOF_UNBOUND_ > /etc/unbound/unbound.conf
+server:
+        verbosity: 1
+        interface: 0.0.0.0
+        port: 53
+        do-ip4: yes
+        do-udp: yes
+        do-tcp: yes
+        access-control: 0.0.0.0/0 allow
+        local-data: "ios.magica-us.com A $i"
+        local-data: "android.magica-us.com A $i"
+        local-data: "magica-us.com A $i"
+        local-data: "app.adjust.com A $i"
+
+python:
+remote-control:
+        control-enable: yes
+        control-interface: 127.0.0.1
+        control-port: 8953
+        control-use-cert: "no"
+
+forward-zone:
+   name: "."
+   forward-addr: 8.8.4.4
+   forward-addr: 8.8.8.8
+_EOF_UNBOUND_
+systemctl restart unbound
+echo "starting gevent server"
+python3 gevent_server.py > /tmp/log 2>&1


### PR DESCRIPTION
This method runs ZipZap in its own self-contained Linux virtual machine. It uses Vagrant to automatically set up and configure the VM, requiring minimal (usually no) human intervention. Aside from the benefit of running ZipZap in its own self-contained environment, this also will allow you to run this on Mac or Linux machines.