### PR TITLE
Move ca install page out of vagrant to nginx windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ options. If the option you choose didn't work, run `vagrant destroy` followed by
 choice.
 
 Once the configuration process is complete, the script will display the VM's IP address. On your device or emulator,
-set the DNS server to that IP address, then open a web browser and go to `https://magica.us`. You should see a page
+set the DNS server to that IP address, then open a web browser and go to `https://magica-us.com`. You should see a page
 asking you to install the custom SSL certificate. Follow the instructions to do this. Now you should be able to run
 Magia Record and connect to your private server!
 

--- a/setupServer.sh
+++ b/setupServer.sh
@@ -33,31 +33,8 @@ systemctl stop nginx.service
 mv /etc/nginx /etc/nginx.bak
 cp -r $SRC/windows/nginx_windows/nginx/conf /etc/nginx
 cp -r $SRC/windows/nginx_windows/nginx/html /etc/nginx/html
-cat << _EOF_HTML_ > /etc/nginx/html/index.html
-<!DOCTYPE html>
-<html>
-<head>
-<title>Welcome to MadokaPriv!</title>
-<style>
-    body {
-        width: 35em;
-        margin: 0 auto;
-        font-family: Tahoma, Verdana, Arial, sans-serif;
-    }
-</style>
-</head>
-<body>
-<h1>Welcome to MadokaPriv!</h1>
-<p>To use MadokaPriv to play with your Magia Record EN private server, you need to install the CA certificate and trust it</p>
-
-<p><a href="ca.crt">Download CA Cert</a>.<br/></p>
-<h2>Guides to enabling a CA Root Certificate</h2>
-<p><a href="https://support.apple.com/en-us/HT204477">iOS/iPadOS</a></p>
-<p><a href="https://www.lastbreach.com/blog/importing-private-ca-certificates-in-android">Android</a></p>
-</body>
-</html>
-_EOF_HTML_
 sed -e 's/^.*root.*html/root \/etc\/nginx\/html/' -i.bak /etc/nginx/nginx.conf
+sed -e 's/^.*root.*conf\/cert/root \/etc\/nginx\/html/' -i.bak /etc/nginx/nginx.conf
 sed -e 's/^error_log.*$/error_log \/var\/log\/nginx\/error.log;/' -i.bak /etc/nginx/nginx.conf
 sed -e 's/^.*access_log.*$/access_log \/var\/log\/nginx\/access.log combined;/' -i.bak /etc/nginx/nginx.conf
 sed -e 's/^daemon/#daemon/' -i.bak /etc/nginx/nginx.conf
@@ -75,7 +52,7 @@ openssl x509 -sha256 -req -in site.req -CA ca.crt -CAkey ca.key -CAcreateserial 
 
 # install cert
 echo ""
-echo "# Installikng SSL certificate and starting up nginx..."
+echo "# Installing SSL certificate and starting up nginx..."
 mkdir -p /etc/nginx/cert /etc/nginx/html
 cp ca.crt /etc/nginx/html
 for FILE in site.crt site.key; do
@@ -86,7 +63,7 @@ systemctl start nginx.service
 
 # install dependencies etc
 echo ""
-echo "# Installikng ZipZap python dependencies..."
+echo "# Installing ZipZap python dependencies..."
 cd $SRC && pip3 install -r requirements.txt
 
 # enable rc.local

--- a/site.conf
+++ b/site.conf
@@ -53,8 +53,8 @@ nsComment           = "OpenSSL Generated Certificate"
 
 DNS.1       = *.magica-us.com
 DNS.2       = magica-us.com
-DNS.3       = *.xn--80axfjoj.xn--p1ai
-DNS.4       = xn--80axfjoj.xn--p1ai
+DNS.3       = *.snaa.services
+DNS.4       = snaa.services
 
 # Add these if you need them. But usually you don't want them or
 #   need them in production. You may need them for development.

--- a/windows/nginx_windows/nginx/conf/nginx.conf
+++ b/windows/nginx_windows/nginx/conf/nginx.conf
@@ -47,6 +47,10 @@ http {
             index  index.html index.htm;
         }
 
+        location = /ca.crt {
+            root conf/cert;
+        }
+
         location /magica/api/ {
             proxy_pass http://127.0.0.1:5000/;
         }

--- a/windows/nginx_windows/nginx/html/index.html
+++ b/windows/nginx_windows/nginx/html/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Welcome to nginx!</title>
+<title>Welcome to ZipZap!</title>
 <style>
     body {
         width: 35em;
@@ -11,15 +11,12 @@
 </style>
 </head>
 <body>
-<h1>Welcome to nginx!</h1>
-<p>If you see this page, the nginx web server is successfully installed and
-working. Further configuration is required.</p>
+<h1>Welcome to ZipZap!</h1>
+<p>To use ZipZap to play with your Magia Record EN private server, you need to install the CA certificate and trust it</p>
 
-<p>For online documentation and support please refer to
-<a href="http://nginx.org/">nginx.org</a>.<br/>
-Commercial support is available at
-<a href="http://nginx.com/">nginx.com</a>.</p>
-
-<p><em>Thank you for using nginx.</em></p>
+<p><a href="ca.crt">Download CA cert</a>.<br/></p>
+<h2>Guides to enabling a CA Root Certificate</h2>
+<p><a href="https://support.apple.com/en-us/HT204477">iOS/iPadOS</a></p>
+<p><a href="https://www.lastbreach.com/blog/importing-private-ca-certificates-in-android">Android</a></p>
 </body>
 </html>


### PR DESCRIPTION
This moves vagrant's ca install page (nice idea btw) to nginx windows so it can be used there too.