### PR TITLE
Fixed Mirrors not working for a team of 5 Megucas.

### DIFF
--- a/api/questEndpoints/get.py
+++ b/api/questEndpoints/get.py
@@ -442,7 +442,7 @@ def dedupeDictList(dictlist, idx):
 
 def addUserToBattle(battleData, position, deck):
     currCardIdx = 0
-    for i in range(4):
+    for i in range(5):
         if 'questPositionId'+str(i+1) in deck:
             if deck['questPositionId'+str(i+1)]==position:
                 currCardIdx = i+1


### PR DESCRIPTION
I was not able to launch a mirrors battle with a team of 5 Megucas. The last card would return currCardIdx = 0 and crash when attempting to get the key 'userCardId0' from the deck.