### PR TITLE
Fixed Live2D data not added when pulling new meguca.

### DIFF
--- a/api/gacha.py
+++ b/api/gacha.py
@@ -221,9 +221,10 @@ def addMeguca(charaId):
         userCard, userChara, userLive2d = newtil.createUserMeguca(charaId)
         dt.setUserObject('userCardList', userCard['id'], userCard)
         dt.setUserObject('userCharaList', charaId, userChara)
+        live2ds += [userLive2d]
 
         if 'doubleUnitFlg' in userChara['chara'] and userChara['chara']['doubleUnitFlg']:
-            live2ds = [userLive2d] + addDuoLive2d(userChara['chara'])
+            live2ds += addDuoLive2d(userChara['chara'])
         live2dPath = 'data/user/userLive2dList.json'
         dt.saveJson(live2dPath, dt.readJson(live2dPath) + live2ds)
     else:


### PR DESCRIPTION
Live2D data was not saved to userLive2dList.json when pulling new character. This caused an error on the Home screen when setting a new character as favorite.